### PR TITLE
TLT-39-Develop-camera-page

### DIFF
--- a/brava/lib/screens/camera.dart
+++ b/brava/lib/screens/camera.dart
@@ -1,529 +1,164 @@
 import 'package:flutter/material.dart';
 
-class Camera extends StatelessWidget {
+import 'package:brava/style/style.dart';
+import 'package:brava/widgets/widgets.dart';
+
+
+class Camera extends StandardPage {
+  const Camera({super.key});
+
+  @override
+  String getPageTitle() {
+    return "Camera Connections";
+  }
+
+  @override
+  Widget getContentWidget() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        // Video preview box.
+        VideoPreviewWidget(),
+        SizedBox(height: 48,),
+        // Connected cameras.
+        ConnectedCameraCard(deviceName: "Use Phone Camera", builtIn: true,),
+        SizedBox(height: 8,),
+        ConnectedCameraCard(deviceName: "Chantelle's iPhone", builtIn: false,),
+        // Fill the space between the connected camera and the bottom buttons.
+        Expanded(child: SizedBox(),),
+        // Add and disconnect camera buttons.
+        Row(
+          children: [
+            PrimaryButton(btnText: "Add Camera",),
+            Expanded(child: SizedBox(),),
+            SecondaryButton(btnText: "Disconnect All",),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+
+class VideoPreviewWidget extends StatelessWidget {
+  const VideoPreviewWidget({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Container(
-          width: 393,
-          height: 852,
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(color: Colors.white),
-          child: Stack(
+    const cornerRad = 10.0;
+
+    return Container(
+      // Border around whole video preview widget.
+      decoration: BoxDecoration(
+        border: Border.all(color: dirtyDuckGrey, width: 2,),
+        borderRadius: BorderRadius.all(Radius.circular(cornerRad)),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          // Video previewer.
+          Stack(
+            alignment: AlignmentDirectional.center,
             children: [
-              Positioned(
-                left: 30,
-                top: 418,
-                child: Opacity(
-                  opacity: 0.80,
-                  child: Container(
-                    width: 333,
-                    height: 48,
-                    decoration: ShapeDecoration(
-                      color: Color(0xFFFFF9FB),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                    ),
+              SizedBox(height: 200),
+              Icon(Icons.videocam_off_outlined, color: dirtyDuckGrey,)
+            ],
+          ),
+          // Bottom control bar of video preview.
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+            decoration: BoxDecoration(
+              color: lightestPink,
+                borderRadius: BorderRadius.vertical(bottom: Radius.circular(cornerRad))
+            ),
+            child: Row(
+              children: [
+                SizedBox(
+                  height: 40,
+                  child: FittedBox(
+                      fit: BoxFit.fitHeight,
+                      child: SwitchWidget()
                   ),
                 ),
-              ),
-              Positioned(
-                left: 30,
-                top: 486,
-                child: Container(
-                  width: 333,
-                  height: 48,
-                  decoration: ShapeDecoration(
-                    color: Color(0xFFFFF9FB),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                  ),
+                SizedBox(width: 4),
+                Text("See Preview"),
+                Expanded(child: SizedBox()),
+                Icon(Icons.fullscreen, color: dirtyDuckGrey),  // Make functional and enable/disable
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+
+enum CameraMenu { rename, properties, disconnect, }
+
+class ConnectedCameraCard extends StatelessWidget {
+  const ConnectedCameraCard({super.key, required this.deviceName, required this.builtIn,});
+
+  final bool builtIn;
+  final String deviceName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 2,),
+      decoration: BoxDecoration(
+        color: lightestPink,
+        borderRadius: BorderRadius.all(Radius.circular(10.0),),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (builtIn)
+            // If the card is for a phone's built in camera, add a checkbox for
+            // enabling/disabling its use.
+            Checkbox(
+              checkColor: bravaPink,
+              // fillColor: WidgetStateProperty.resolveWith(getColor),
+              value: false,
+              onChanged: (bool? value) {},
+            )
+          else
+            // Else add padding, since the checkbox normally creates a visual gap.
+            SizedBox(width: 16,),
+          Text(
+            deviceName,
+            style: TextStyle(color: stagePink,),
+          ),
+          Expanded(child: SizedBox(),),
+          PopupMenuButton(
+            iconColor: stagePink,
+            itemBuilder: (BuildContext context) => <PopupMenuEntry<CameraMenu>>[
+              const PopupMenuItem<CameraMenu>(
+                value: CameraMenu.rename,
+                child: ListTile(
+                  leading: Icon(Icons.edit_outlined),
+                  title: Text('Rename'),
                 ),
               ),
-              Positioned(
-                left: 76,
-                top: 433,
-                child: Text(
-                  'Use phone camera',
-                  style: TextStyle(
-                    color: Color(0xFF131214),
-                    fontSize: 16,
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w400,
-                  ),
+              const PopupMenuItem<CameraMenu>(
+                value: CameraMenu.properties,
+                child: ListTile(
+                  leading: Icon(Icons.description_outlined),
+                  title: Text('Properties'),
                 ),
               ),
-              Positioned(
-                left: 47,
-                top: 496,
-                child: SizedBox(
-                  width: 150,
-                  height: 30,
-                  child: Text(
-                    'Janet’s iPhone',
-                    style: TextStyle(
-                      color: Color(0xFF131214),
-                      fontSize: 16,
-                      fontFamily: 'Figtree',
-                      fontWeight: FontWeight.w400,
-                    ),
-                  ),
+              const PopupMenuDivider(),
+              const PopupMenuItem<CameraMenu>(
+                value: CameraMenu.disconnect,
+                child: ListTile(
+                  leading: Icon(Icons.sensors_off),
+                  title: Text('Disconnect'),
                 ),
-              ),
-              Positioned(
-                left: 47,
-                top: 435,
-                child: Container(
-                  width: 16,
-                  height: 16,
-                  decoration: ShapeDecoration(
-                    shape: RoundedRectangleBorder(
-                      side: BorderSide(width: 1, color: Color(0xFFFFDEEA)),
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 30,
-                top: 96,
-                child: Container(
-                  width: 333,
-                  height: 271,
-                  decoration: ShapeDecoration(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                  ),
-                  child: Stack(
-                    children: [
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        child: Container(
-                          width: 333,
-                          height: 271,
-                          decoration: ShapeDecoration(
-                            shape: RoundedRectangleBorder(
-                              side: BorderSide(width: 1, color: Color(0xFFCDC0C0)),
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 44,
-                top: 335,
-                child: Container(
-                  width: 41,
-                  height: 22,
-                  decoration: ShapeDecoration(
-                    color: Color(0xFFCDC0C0),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(36),
-                    ),
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 47,
-                top: 338,
-                child: Container(
-                  width: 16,
-                  height: 16,
-                  decoration: ShapeDecoration(
-                    color: Colors.white,
-                    shape: OvalBorder(),
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 98,
-                top: 336,
-                child: Text(
-                  'See preview',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Color(0xFF131214),
-                    fontSize: 16,
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w400,
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 35,
-                top: 693,
-                child: Container(
-                  width: 150,
-                  height: 44,
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
-                  decoration: ShapeDecoration(
-                    color: Color(0xFFFFDEEA),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(31),
-                    ),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    spacing: 10,
-                    children: [
-                      Text(
-                        '+ Add Camera',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Color(0xFF390A17),
-                          fontSize: 16,
-                          fontFamily: 'Figtree',
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 22,
-                top: 778,
-                child: Container(
-                  width: 350,
-                  height: 50,
-                  child: Stack(
-                    children: [
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        child: Container(
-                          width: 350,
-                          height: 50,
-                          decoration: ShapeDecoration(
-                            color: Colors.white,
-                            shape: RoundedRectangleBorder(
-                              side: BorderSide(width: 0.50, color: Color(0xFFE7E7E7)),
-                              borderRadius: BorderRadius.circular(34),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 34,
-                        top: 13,
-                        child: Container(
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            spacing: 43,
-                            children: [
-                              Container(
-                                width: 20,
-                                height: 20,
-                                decoration: BoxDecoration(
-                                  image: DecorationImage(
-                                    image: NetworkImage("https://placehold.co/20x20"),
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
-                              ),
-                              Container(
-                                width: 24,
-                                height: 24,
-                                decoration: BoxDecoration(
-                                  image: DecorationImage(
-                                    image: NetworkImage("https://placehold.co/24x24"),
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
-                              ),
-                              Container(
-                                width: 24,
-                                height: 24,
-                                decoration: BoxDecoration(
-                                  image: DecorationImage(
-                                    image: NetworkImage("https://placehold.co/24x24"),
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
-                              ),
-                              Container(
-                                width: 22,
-                                height: 22,
-                                decoration: BoxDecoration(
-                                  image: DecorationImage(
-                                    image: NetworkImage("https://placehold.co/22x22"),
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
-                              ),
-                              Container(width: 20, height: 20, child: Stack()),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 208,
-                top: 693,
-                child: Container(
-                  width: 150,
-                  height: 44,
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
-                  decoration: ShapeDecoration(
-                    color: Color(0xFFFFF9FB),
-                    shape: RoundedRectangleBorder(
-                      side: BorderSide(width: 1, color: Color(0xFFFFDEEA)),
-                      borderRadius: BorderRadius.circular(31),
-                    ),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    spacing: 10,
-                    children: [
-                      Text(
-                        'Disconnect All',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Color(0xFF390A17),
-                          fontSize: 16,
-                          fontFamily: 'Figtree',
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 329,
-                top: 422,
-                child: Text(
-                  '...',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Color(0xFF131214),
-                    fontSize: 20,
-                    fontFamily: 'Aoboshi One',
-                    fontWeight: FontWeight.w400,
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 329,
-                top: 488,
-                child: Text(
-                  '...',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Color(0xFF131214),
-                    fontSize: 20,
-                    fontFamily: 'Aoboshi One',
-                    fontWeight: FontWeight.w400,
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 50,
-                top: 438,
-                child: Container(
-                  width: 10,
-                  height: 10,
-                  decoration: ShapeDecoration(
-                    color: Color(0xFFFD6D93),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(3)),
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 0,
-                top: 76,
-                child: Container(
-                  width: 393,
-                  decoration: ShapeDecoration(
-                    shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        width: 1,
-                        strokeAlign: BorderSide.strokeAlignCenter,
-                        color: Color(0xFFFFF9FB),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 31,
-                top: 49,
-                child: Text(
-                  'Camera Connections',
-                  style: TextStyle(
-                    color: Color(0xFF390A17),
-                    fontSize: 16,
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 31,
-                top: 49,
-                child: Text(
-                  'Camera Connections',
-                  style: TextStyle(
-                    color: Color(0xFF131214),
-                    fontSize: 16,
-                    fontFamily: 'Figtree',
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 329,
-                top: 336,
-                child: Container(
-                  width: 20,
-                  height: 20,
-                  clipBehavior: Clip.antiAlias,
-                  decoration: ShapeDecoration(
-                    shape: RoundedRectangleBorder(
-                      side: BorderSide(color: Color(0xFF390A17)),
-                    ),
-                  ),
-                  child: Stack(
-                    children: [
-                      Positioned(
-                        left: 1.50,
-                        top: 12,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 0,
-                        top: 18.50,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 0,
-                        top: 7.25,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 20,
-                        top: 12,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 20,
-                        top: 20,
-                        child: Container(
-                          width: 9,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 20,
-                        top: 1.50,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: 18.50,
-                        top: 8.12,
-                        child: Container(
-                          width: 8,
-                          height: 1.50,
-                          decoration: ShapeDecoration(
-                            color: Color(0xFFD9D9D9),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(1000),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Positioned(
-                left: 185,
-                top: 211,
-                child: Container(width: 24, height: 24, child: Stack()),
               ),
             ],
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/brava/lib/screens/home.dart
+++ b/brava/lib/screens/home.dart
@@ -8,23 +8,25 @@ class Home extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        // Welcome text.
-        const Text("Hello Jacaitelle!\nHere's your daily summary.", textAlign: TextAlign.center, style: TextStyle(fontFamily: 'Figtree', fontWeight: FontWeight.w700)),
-        // Spacing
-        SizedBox(height: 24),
-        // Button: Start Session.
-        const PrimaryButton(btnText: "Start Session",),
-        SizedBox(height: 48),
-        TlProgressIndicator(),
-        SizedBox(height: 24),
-        MovementCountRow(),
-        SizedBox(height: 48),
-        // Button: Complete today's self assessment.
-        const PrimaryButton(btnText: "Complete Today's Self Assessment")
-      ],
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          // Welcome text.
+          const Text("Hello Jacaitellerie!\nHere's your daily summary.", textAlign: TextAlign.center, style: TextStyle(fontFamily: 'Figtree', fontWeight: FontWeight.w700)),
+          // Spacing
+          SizedBox(height: 24),
+          // Button: Start Session.
+          const PrimaryButton(btnText: "Start Session",),
+          SizedBox(height: 48),
+          TlProgressIndicator(),
+          SizedBox(height: 24),
+          MovementCountRow(),
+          SizedBox(height: 48),
+          // Button: Complete today's self assessment.
+          const PrimaryButton(btnText: "Complete Today's Self Assessment")
+        ],
+      ),
     );
   }
 }

--- a/brava/lib/style/style.dart
+++ b/brava/lib/style/style.dart
@@ -11,6 +11,9 @@ const dirtyDuckGrey = Color(0xFFCDC1C1);
 const stagePink = Color(0xFF390A17);
 const marleyBlack = Color(0xFF131214);
 
+const edgePadH = 32.0;  // Standard padding from the edge of the screen.
+const edgePadTop = 64.0;  // Standard padding from the top of the screen.
+
 final bravaAppTheme = ThemeData(
   // The theme of the application.
   // Most important attributes: colorScheme and textTheme.

--- a/brava/lib/widgets/widgets.dart
+++ b/brava/lib/widgets/widgets.dart
@@ -2,6 +2,64 @@ import 'package:flutter/material.dart';
 import 'package:brava/style/style.dart';
 
 
+class StandardPage extends StatelessWidget {
+  const StandardPage({super.key});
+
+  String getPageTitle() {
+    throw UnimplementedError();
+  }
+
+  Widget getContentWidget() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        children: [
+          SizedBox(height: edgePadTop,),
+          PageHeader(pageTitle: getPageTitle(),),
+          SizedBox(height: 16,),
+          Expanded(
+            child: Container(
+              margin: EdgeInsets.symmetric(horizontal: 32,),
+              child: getContentWidget(),
+            )
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+
+class PageHeader extends StatelessWidget {
+  const PageHeader({super.key, this.pageTitle=""});
+
+  final String pageTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.only(left: edgePadH, right: edgePadH, bottom: 8,),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: lightestPink, width: 2,),),
+      ),
+      child: Row(
+        children: [
+          Text(
+              pageTitle,
+              style: TextStyle(color: marleyBlack, fontWeight: FontWeight.w700),
+          ),
+          Expanded(child: SizedBox(),),
+        ],
+      ),
+    );
+  }
+}
+
+
 class PrimaryButton extends StatelessWidget {
   const PrimaryButton({super.key, this.btnText=""});
 
@@ -16,6 +74,62 @@ class PrimaryButton extends StatelessWidget {
       ),
       onPressed: () {},
       child: Text(btnText),
+    );
+  }
+}
+
+
+class SecondaryButton extends StatelessWidget {
+  const SecondaryButton({super.key, this.btnText=""});
+
+  final String btnText;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      style: OutlinedButton.styleFrom(
+        backgroundColor: lightestPink,
+        foregroundColor: stagePink,
+        side: BorderSide(color: lightPink,),
+      ),
+      onPressed: () {},
+      child: Text(btnText,),
+    );
+  }
+}
+
+
+class SwitchWidget extends StatefulWidget {
+  const SwitchWidget({super.key});
+
+  @override
+  State<SwitchWidget> createState() => _SwitchWidgetState();
+}
+
+class _SwitchWidgetState extends State<SwitchWidget> {
+  bool light = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch(
+      // This bool value toggles the switch.
+      value: light,
+      activeTrackColor: bravaPink,  // Background colour (active).
+      activeColor: Colors.white,  // Small, inner circle.
+      inactiveTrackColor: dirtyDuckGrey.withAlpha(50),  // Background colour (inactive).
+      inactiveThumbColor: Colors.grey.shade500,  // Small, inner circle.
+      trackOutlineColor: WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {  // Border colour (inactive).
+        if (states.contains(WidgetState.selected)) {
+          return Colors.transparent;
+        }
+        return Colors.grey.shade500; // Use the default color.
+      }),
+      onChanged: (bool value) {
+        // This is called when the user toggles the switch.
+        setState(() {
+          light = value;
+        });
+      },
     );
   }
 }

--- a/brava/test/widget_test.dart
+++ b/brava/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:brava/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const Brava());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Refactored camera page
- Wrapped the home page in a Center() widget to vertically center it
- Added more common widgets to support the camera page: secondary button, switch (classic toggle), checkbox (not fully functional though)
- Created StandardPage widget, which includes a header, and pads the page's main widget on the left and right so the widgets don't go to the edge of the screen
![image](https://github.com/user-attachments/assets/3fe14349-db58-4ed5-bb9a-c21a03f841c3)
![image](https://github.com/user-attachments/assets/ca75a919-8dff-42bc-8b5b-2384c0b36f62)
![image](https://github.com/user-attachments/assets/5b2922c6-2702-4adf-8dc6-909bc6c505fa)
![image](https://github.com/user-attachments/assets/db295825-b088-43d2-b94a-4dba85925576)
