### PR TITLE
TLT-58-Add-integrated-camera-functionality-in-app

### DIFF
--- a/brava/lib/main.dart
+++ b/brava/lib/main.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
+
 import 'package:brava/style/style.dart';
-import 'screens/loading.dart';
 import 'screens/home.dart';
 import 'screens/camera.dart';
 import 'screens/stats.dart';
-import 'screens/stats2.dart';
 import 'screens/limits.dart';
 
 

--- a/brava/lib/screens/home.dart
+++ b/brava/lib/screens/home.dart
@@ -104,11 +104,11 @@ class _RunSessionWidgetState extends State<RunSessionWidget> {
     return Column(
       children: [
         running
-            ? SecondaryButton(
+        ? SecondaryButton(
           text: "End Session",
           onPressed: _toggleRecording,
         )
-            : PrimaryButton(
+        : PrimaryButton(
           text: "Start Session",
           onPressed: _toggleRecording,
         ),

--- a/brava/lib/screens/limits.dart
+++ b/brava/lib/screens/limits.dart
@@ -13,7 +13,7 @@ class Limits extends StandardPage {
   }
 
   @override
-  Widget getContentWidget() {
+  Widget getContentWidget(BuildContext context) {
     return LimitsContent();
   }
 }

--- a/brava/lib/screens/stats.dart
+++ b/brava/lib/screens/stats.dart
@@ -14,7 +14,7 @@ class Stats extends StandardPage {
   }
 
   @override
-  Widget getContentWidget() {
+  Widget getContentWidget(BuildContext context) {
     return Column(
       children: [
         // Toggle for Daily / Weekly / Monthly / Yearly breakdown.

--- a/brava/lib/widgets/widgets.dart
+++ b/brava/lib/widgets/widgets.dart
@@ -9,7 +9,7 @@ class StandardPage extends StatelessWidget {
     throw UnimplementedError();
   }
 
-  Widget getContentWidget() {
+  Widget getContentWidget(BuildContext context) {
     throw UnimplementedError();
   }
 
@@ -24,7 +24,7 @@ class StandardPage extends StatelessWidget {
           Expanded(
             child: Container(
               margin: EdgeInsets.symmetric(horizontal: ScreenPadding.edgePadH,),
-              child: getContentWidget(),
+              child: getContentWidget(context),
             )
           ),
         ],
@@ -110,7 +110,9 @@ class SecondaryButton extends StatelessWidget {
 
 
 class SwitchWidget extends StatefulWidget {
-  const SwitchWidget({super.key});
+  const SwitchWidget({super.key, required this.onChanged});
+
+  final VoidCallback onChanged;
 
   @override
   State<SwitchWidget> createState() => _SwitchWidgetState();
@@ -139,6 +141,7 @@ class _SwitchWidgetState extends State<SwitchWidget> {
         setState(() {
           light = value;
         });
+        widget.onChanged();
       },
     );
   }

--- a/brava/pubspec.yaml
+++ b/brava/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   expandable: ^5.0.1
+  camera: ^0.11.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When the switch button on the camera preview widget is toggled, a camera preview now appears on the app!
Added the camera package to accomplish this.
Also made some slight adjustments to the overall UI.

![image](https://github.com/user-attachments/assets/35b7b624-13b7-481a-a611-0651f707d3d1)
![image](https://github.com/user-attachments/assets/7293cada-2004-4c1c-a6c3-d782bbbeb22a)
